### PR TITLE
Dropped Digest::SHA1 dependency (RT#70531)

### DIFF
--- a/META.yml
+++ b/META.yml
@@ -7,7 +7,6 @@ installdirs:  site
 requires:
     Cache::FileCache:              0
     Carp:                          0
-    Digest::SHA1:                  0
     Error:                         0
     HTML::TokeParser:              2.28
     LWP::Simple:                   1.41

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -25,7 +25,6 @@ WriteMakefile(
 							'Cache::FileCache'	=> 0, 
 							'Carp'				=> 0,
 							'Error'				=> 0,
-							'Digest::SHA1'		=> 0,
 							'Pod::Checker'		=> 0,
 							'HTML::Entities'	=> 0,
 							'Text::Unidecode'	=> 0,


### PR DESCRIPTION
Hi, I've dropped unnecessary `Digest::SHA1` dependency (see [RT#70531](https://rt.cpan.org/Public/Bug/Display.html?id=70531))

This PR is part of my [advent quest](https://questhub.io/realm/perl/quest/547b4202070ccf750d00010e).

Cheers,
Sergey.
